### PR TITLE
fix: add --privileged --network=host running pod inside

### DIFF
--- a/vars/amambaCustomStep.groovy
+++ b/vars/amambaCustomStep.groovy
@@ -43,7 +43,7 @@ config format:
 
 def genRunArgs(Map config) {
     def workspace = pwd()
-    runArgs = ""
+    runArgs = "--privileged --network=host"
 
     if (config.docker.entrypoint) {
         runArgs = "--entrypoint=${config.docker.entrypoint} "


### PR DESCRIPTION
当在容器里面启动容器的时候，尤其是 podman build/run 需要--privileged才能启动，需要 --network=host才能访问网络